### PR TITLE
Add support for vector-compat

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,6 +79,13 @@
 
         <div class="checkbox">
             <label>
+              <input type="checkbox" id="add-vector-compat" onchange="addVectorCompatSupport(this);">Add <a target="_blank" href="https://github.com/wnafee/vector-compat">vector-compat</a> tags (for Android 4.0+ support)
+            </label>
+
+        </div>
+
+        <div class="checkbox">
+            <label>
                 <input type="checkbox" id="bake-transforms" onchange="bakeTransforms(this);"><i>Bake transforms into path (experimental)</i>
             </label>
         </div>


### PR DESCRIPTION
The [vector-compat](https://github.com/wnafee/vector-compat) library brings support for vector drawables back to Android 4.0+, but the vector files require some additional tags to make it work. This adds a checkbox to this webapp to make it so you can toggle vector-compat support.

Demo:

![animated](https://cloud.githubusercontent.com/assets/283842/9176668/b2c155a6-3f5a-11e5-92d2-d6d4f5dfeac2.gif)
