### PR TITLE
Missing style section in SVG causes svgStyles.children to be undefined

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -309,7 +309,7 @@ function parseStyles(path) {
             parseCssAttributes(stylesArray, cssAttributes);
         } else if (name == "class") {
             var val = "." + value.trim();
-            if (typeof svgStyles.children[val] !== "undefined") {
+            if (typeof svgStyles.children !== "undefined" && typeof svgStyles.children[val] !== "undefined") {
                 parseCssAttributes(stylesArray, svgStyles.children[val].attributes);
             }
         } else {


### PR DESCRIPTION
Simple SVG files generated by Inkscape might not have a styles section, but can have orphaned class definitions. The parser does not expect this and will throw an exception without producing any output.
