### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Extracts all parameters of elements and groups that are supported in Android.
 ##### Example of imported svg (random image from wikipedia):
 ![](https://github.com/inloop/svg2android/raw/gh-pages/img/example_imported_svg.png "Screenshot")
 
-###License
+### License
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
